### PR TITLE
JMSSerializer namespace change

### DIFF
--- a/Service/Command/JMSSerializerResponseParser.php
+++ b/Service/Command/JMSSerializerResponseParser.php
@@ -14,7 +14,7 @@ namespace Misd\GuzzleBundle\Service\Command;
 use Guzzle\Http\Message\Response;
 use Guzzle\Service\Command\AbstractCommand;
 use Guzzle\Service\Command\DefaultResponseParser;
-use JMS\SerializerBundle\Serializer\Serializer;
+use JMS\Serializer\Serializer;
 
 /**
  * JMSSerializerBundle-enabled response parser.

--- a/Service/Command/LocationVisitor/Request/JMSSerializerBodyVisitor.php
+++ b/Service/Command/LocationVisitor/Request/JMSSerializerBodyVisitor.php
@@ -15,7 +15,7 @@ use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Service\Command\CommandInterface;
 use Guzzle\Service\Command\LocationVisitor\Request\BodyVisitor;
 use Guzzle\Service\Description\Parameter;
-use JMS\SerializerBundle\Serializer\Serializer;
+use JMS\Serializer\Serializer;
 
 /**
  * JMSSerializerBundle-enabled request body visitor.

--- a/Tests/Fixtures/Person.php
+++ b/Tests/Fixtures/Person.php
@@ -11,7 +11,7 @@
 
 namespace Misd\GuzzleBundle\Tests\Fixtures;
 
-use JMS\SerializerBundle\Annotation as Serializer;
+use JMS\Serializer\Annotation as Serializer;
 
 /** @Serializer\XmlRoot("person") */
 class Person

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -24,4 +24,4 @@ EOT
     );
 }
 
-AnnotationRegistry::registerAutoloadNamespaces(array('JMS\\SerializerBundle' => __DIR__.'/../vendor/jms/serializer-bundle/'));
+AnnotationRegistry::registerAutoloadNamespaces(array('JMS\\Serializer' => __DIR__.'/../vendor/jms/serializer/src'));

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,13 @@
         "symfony/form":">=2.0,<2.2-dev",
         "symfony/yaml":">=2.0,<2.2-dev",
         "symfony/monolog-bundle":"2.1.*",
-        "jms/serializer-bundle":"*"
+        "jms/serializer-bundle":"1.0.*"
     },
     "autoload":{
         "psr-0":{
             "Misd\\GuzzleBundle":""
         }
     },
-    "target-dir":"Misd/GuzzleBundle"
+    "target-dir":"Misd/GuzzleBundle",
+    "minimum-stability":"dev"
 }


### PR DESCRIPTION
Updated the namespace changes in the latest JMSSerializerBundle (Serializer was moved to a separate library).
