### PR TITLE
Change references to JMSSerializer concrete class to interface

### DIFF
--- a/Service/Command/JMSSerializerResponseParser.php
+++ b/Service/Command/JMSSerializerResponseParser.php
@@ -14,7 +14,7 @@ namespace Misd\GuzzleBundle\Service\Command;
 use Guzzle\Http\Message\Response;
 use Guzzle\Service\Command\AbstractCommand;
 use Guzzle\Service\Command\DefaultResponseParser;
-use JMS\Serializer\Serializer;
+use JMS\SerializerBundle\Serializer\SerializerInterface;
 
 /**
  * JMSSerializerBundle-enabled response parser.
@@ -26,16 +26,16 @@ class JMSSerializerResponseParser extends DefaultResponseParser
     /**
      * Serializer.
      *
-     * @var Serializer|null
+     * @var SerializerInterface|null
      */
     protected $serializer;
 
     /**
      * Constructor.
      *
-     * @param Serializer|null $serializer Serializer, or null if not used.
+     * @param SerializerInterface|null $serializer SerializerInterface, or null if not used.
      */
-    public function __construct(Serializer $serializer = null)
+    public function __construct(SerializerInterface $serializer = null)
     {
         $this->serializer = $serializer;
     }

--- a/Service/Command/LocationVisitor/Request/JMSSerializerBodyVisitor.php
+++ b/Service/Command/LocationVisitor/Request/JMSSerializerBodyVisitor.php
@@ -15,7 +15,7 @@ use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Service\Command\CommandInterface;
 use Guzzle\Service\Command\LocationVisitor\Request\BodyVisitor;
 use Guzzle\Service\Description\Parameter;
-use JMS\Serializer\Serializer;
+use JMS\SerializerBundle\Serializer\SerializerInterface;
 
 /**
  * JMSSerializerBundle-enabled request body visitor.
@@ -27,16 +27,16 @@ class JMSSerializerBodyVisitor extends BodyVisitor
     /**
      * Serializer.
      *
-     * @var Serializer|null
+     * @var SerializerInterface|null
      */
     protected $serializer;
 
     /**
      * Constructor.
      *
-     * @param Serializer|null $serializer Serializer, or null if not used.
+     * @param SerializerInterface|null $serializer SerializerInterface, or null if not used.
      */
-    public function __construct(Serializer $serializer = null)
+    public function __construct(SerializerInterface $serializer = null)
     {
         $this->serializer = $serializer;
     }


### PR DESCRIPTION
I ran into trouble with the type hinting when using JMSSerializerBundle. I think using these interfaces as type hints should solve the problem.
Using jms/serializer 0.11.0 and jms/serializer-bundle 0.10
