### PR TITLE
Let any class response type be passed to the serializer

### DIFF
--- a/Resources/doc/serialization.md
+++ b/Resources/doc/serialization.md
@@ -34,6 +34,24 @@ Executing the `GetPerson` command will now return an instance of `Vendor\MyBundl
     $command = $client->getCommand('GetPerson', array('id' => $id));
     $person = $client->execute($command);
 
+### Arrays
+
+The `responseClass` value can actually be any of the JMS Serializer's `@Type` annotation value forms which contain a classname.
+
+For example, to deserialize a JSON array that doesn't have a root element:
+
+    "GetPeople":{
+        "httpMethod":"GET",
+        "uri":"people",
+        "summary":"Gets an array of people",
+        "responseClass":"array<Vendor\\MyBundle\\Entity\\Person>"
+    }
+
+Executing the `GetPeople` command will now return an array of `Vendor\MyBundle\Entity\Person` instances:
+
+    $command = $client->getCommand('GetPeople');
+    $people = $client->execute($command);
+
 Requests
 --------
 

--- a/Service/Command/JMSSerializerResponseParser.php
+++ b/Service/Command/JMSSerializerResponseParser.php
@@ -14,6 +14,7 @@ namespace Misd\GuzzleBundle\Service\Command;
 use Guzzle\Http\Message\Response;
 use Guzzle\Service\Command\AbstractCommand;
 use Guzzle\Service\Command\DefaultResponseParser;
+use Guzzle\Service\Description\OperationInterface;
 use JMS\Serializer\SerializerInterface;
 
 /**
@@ -73,7 +74,9 @@ class JMSSerializerResponseParser extends DefaultResponseParser
                 $serializerContentType = null;
             }
 
-            if (null !== $serializerContentType && class_exists($command->getOperation()->getResponseClass())) {
+            if (null !== $serializerContentType &&
+                OperationInterface::TYPE_CLASS === $command->getOperation()->getResponseType()
+            ) {
                 return $this->serializer->deserialize(
                     $response->getBody(),
                     $command->getOperation()->getResponseClass(),

--- a/Tests/Fixtures/config/client.json
+++ b/Tests/Fixtures/config/client.json
@@ -29,6 +29,26 @@
                 }
             }
         },
+        "GetPersonInvalidClass":{
+            "httpMethod":"GET",
+            "uri":"person/{id}",
+            "summary":"Get a person",
+            "responseClass":"Misd\\GuzzleBundle\\Tests\\Fixtures\\NonExistentPerson",
+            "parameters":{
+                "id":{
+                    "location":"query",
+                    "description":"Person to retrieve by ID",
+                    "type":"integer",
+                    "required":true
+                }
+            }
+        },
+        "GetPersonClassArray":{
+            "httpMethod":"GET",
+            "uri":"person",
+            "summary":"Get an array of people",
+            "responseClass":"array<Misd\\GuzzleBundle\\Tests\\Fixtures\\Person>"
+        },
         "AddPerson":{
             "httpMethod":"POST",
             "uri":"person",

--- a/Tests/Functional/JMSSerializerResponseTest.php
+++ b/Tests/Functional/JMSSerializerResponseTest.php
@@ -136,6 +136,47 @@ class JMSSerializerResponseTest extends TestCase
     }
 
     /**
+     * @expectedException \Exception
+     */
+    public function testGetPersonInvalidClassXmlResponseWithSerializer()
+    {
+        $client = self::getClient('JMSSerializerBundle');
+        $command = $client->getCommand('GetPersonInvalidClass', array('id' => 1));
+        self::$mock->addResponse(Response::fromMessage(self::xmlResponse()));
+        $client->execute($command);
+    }
+
+    public function testGetPersonInvalidClassXmlResponseWithoutSerializer()
+    {
+        $client = self::getClient('Basic');
+        $command = $client->getCommand('GetPersonInvalidClass', array('id' => 1));
+        self::$mock->addResponse(Response::fromMessage(self::xmlResponse()));
+
+        $this->assertInstanceOf('SimpleXMLElement', $client->execute($command));
+    }
+
+    public function testGetPersonClassArrayJsonResponseWithSerializer()
+    {
+        $client = self::getClient('JMSSerializerBundle');
+        $command = $client->getCommand('GetPersonClassArray');
+        self::$mock->addResponse(Response::fromMessage(self::jsonArrayResponse()));
+        $people = $client->execute($command);
+
+        $this->assertTrue(is_array($people));
+        $this->assertCount(2, $people);
+
+        $this->assertInstanceOf('Misd\GuzzleBundle\Tests\Fixtures\Person', $people[0]);
+        $this->assertEquals(1, $people[0]->id);
+        $this->assertEquals('Foo', $people[0]->firstName);
+        $this->assertEquals('Bar', $people[0]->familyName);
+
+        $this->assertInstanceOf('Misd\GuzzleBundle\Tests\Fixtures\Person', $people[1]);
+        $this->assertEquals(2, $people[1]->id);
+        $this->assertEquals('Baz', $people[1]->firstName);
+        $this->assertEquals('Qux', $people[1]->familyName);
+    }
+
+    /**
      * @var Client[]
      */
     protected static $clients = array();
@@ -194,6 +235,19 @@ Server: Test
 Content-Type: application/json
 
 {"id":1,"name":"Foo","family-name":"Bar"}
+EOT;
+    }
+
+    protected function jsonArrayResponse()
+    {
+        return <<<EOT
+HTTP/1.1 200 OK
+Date: Wed, 25 Nov 2009 12:00:00 GMT
+Connection: close
+Server: Test
+Content-Type: application/json
+
+[{"id":1,"name":"Foo","family-name":"Bar"},{"id":2,"name":"Baz","family-name":"Qux"}]
 EOT;
     }
 


### PR DESCRIPTION
This fixes #13 by letting the Serializer throw a `ReflectionException`.

It also has the added benefit of allowing the `responseClass` value to be a Serializer array form (eg a JSON response without a root element can be deserialized by setting it to `array<Vendor\\MyBundle\\Entity\\Person>`).

(Note that `ArrayCollection<Vendor\\MyBundle\\Entity\\Person>` isn't supported until https://github.com/schmittjoh/serializer/issues/9 is fixed.)
