### PR TITLE
Allow arrays to be serialized as body parameters

### DIFF
--- a/Service/Command/LocationVisitor/Request/JMSSerializerBodyVisitor.php
+++ b/Service/Command/LocationVisitor/Request/JMSSerializerBodyVisitor.php
@@ -46,7 +46,7 @@ class JMSSerializerBodyVisitor extends BodyVisitor
      */
     public function visit(CommandInterface $command, RequestInterface $request, Parameter $param, $value)
     {
-        if (null !== $this->serializer && is_object($value)) {
+        if (null !== $this->serializer && (is_object($value) || is_array($value))) {
             switch ($param->getSentAs()) {
                 case 'json':
                     $request->setHeader('Content-Type', 'application/json');

--- a/Tests/Fixtures/config/client.json
+++ b/Tests/Fixtures/config/client.json
@@ -69,6 +69,19 @@
                     "required":"true"
                 }
             }
+        },
+        "UpdatePeopleJson":{
+            "httpMethod":"POST",
+            "uri":"updatePeople",
+            "summary":"Update people",
+            "parameters":{
+                "people":{
+                    "location":"body",
+                    "type":"array",
+                    "sentAs":"json",
+                    "required":"true"
+                }
+            }
         }
     }
 }

--- a/Tests/Functional/JMSSerializerRequestTest.php
+++ b/Tests/Functional/JMSSerializerRequestTest.php
@@ -61,6 +61,36 @@ class JMSSerializerRequestTest extends TestCase
         );
     }
 
+    public function testUpdatePeopleRequest()
+    {
+        // Set fixtures
+        $personOne = new Person();
+        $personOne->id = 1;
+        $personOne->firstName = 'Foo';
+        $personOne->familyName = 'Bar';
+
+        $personTwo = new Person();
+        $personTwo->id = 2;
+        $personTwo->firstName = 'Baz';
+        $personTwo->familyName = 'Fam';
+
+        $people = array($personOne, $personTwo);
+        // End fixtures
+
+        $client = self::getClient('JMSSerializerBundle');
+
+        $command = $client->getCommand('UpdatePeopleJson', array('people' => $people));
+        self::$mock->addResponse(Response::fromMessage(self::response()));
+        $response = $client->execute($command);
+        $request = $response->getRequest();
+
+        $this->assertEquals('application/json', $request->getHeader('Content-Type'));
+        $this->assertEquals(
+            $request->getBody(),
+            self::getContainer('JMSSerializerBundle')->get('serializer')->serialize($people, 'json')
+        );
+    }
+
     protected function person()
     {
         $person = new Person();


### PR DESCRIPTION
I noticed that you can't include in the body serialized arrays when using the JMSSerializer visitor. It's simple to change this and allow arrays in the body if that is a desired feature.
