### PR TITLE
Param Converter Passes Original Guzzle Exception

### DIFF
--- a/Request/ParamConverter/GuzzleParamConverter.php
+++ b/Request/ParamConverter/GuzzleParamConverter.php
@@ -94,7 +94,7 @@ class GuzzleParamConverter implements ParamConverterInterface
             if (true === $configuration->isOptional()) {
                 $result = null;
             } elseif (404 === $e->getResponse()->getStatusCode()) {
-                throw new NotFoundHttpException(sprintf('%s object not found.', $class));
+                throw new NotFoundHttpException(sprintf('%s object not found.', $class), $e);
             } else {
                 throw $e;
             }


### PR DESCRIPTION
When the GuzzleParamConverter finds a 404 error, the bundle throws a
NotFoundHttpException. This commit modifies that thrown exception to
also include with it the original Guzzle Exception.

This allows listeners of kernal.exception to check the
NotFoundHttpException for any BadResponseExceptions and work with the
additional information in the Guzzle request or response objects
attached to the BadResponseException.
