### PR TITLE
compatibility with latest guzzle master branch changes

### DIFF
--- a/Service/Command/JMSSerializerResponseParser.php
+++ b/Service/Command/JMSSerializerResponseParser.php
@@ -13,6 +13,7 @@ namespace Misd\GuzzleBundle\Service\Command;
 
 use Guzzle\Http\Message\Response;
 use Guzzle\Service\Command\AbstractCommand;
+use Guzzle\Service\Command\CommandInterface;
 use Guzzle\Service\Command\DefaultResponseParser;
 use Guzzle\Service\Description\OperationInterface;
 use JMS\Serializer\SerializerInterface;
@@ -44,7 +45,7 @@ class JMSSerializerResponseParser extends DefaultResponseParser
     /**
      * {@inheritdoc}
      */
-    protected function handleParsing(AbstractCommand $command, Response $response, $contentType)
+    protected function handleParsing(CommandInterface $command, Response $response, $contentType)
     {
         $deserialized = $this->deserialize($command, $response, $contentType);
 


### PR DESCRIPTION
Runtime Notice: Declaration of Misd\GuzzleBundle\Service\Command\JMSSerializerResponseParser::handleParsing() should be compatible with Guzzle\Service\Command\DefaultResponseParser::handleParsing(Guzzle\Service\Command\CommandInterface $command, Guzzle\Http\Message\Response $response, $contentType)

Guzzle changes: https://github.com/guzzle/guzzle/commit/4fee72e77a3f252199767487ed04612b92c5164a#src/Guzzle/Service/Command/DefaultResponseParser.php
