### PR TITLE
Added timing information to Guzzle profiler panel

### DIFF
--- a/DataCollector/GuzzleDataCollector.php
+++ b/DataCollector/GuzzleDataCollector.php
@@ -11,6 +11,7 @@
 
 namespace Misd\GuzzleBundle\DataCollector;
 
+use Guzzle\Http\Message\Response as GuzzleResponse;
 use Guzzle\Log\ArrayLogAdapter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,12 +30,24 @@ class GuzzleDataCollector extends DataCollector
     {
         foreach ($this->logAdapter->getLogs() as $log) {
             $datum['message'] = $log['message'];
+            $datum['time'] =  $this->getRequestTime($log['extras']['response']);
             $datum['request'] = (string) $log['extras']['request'];
-            $datum['response'] = (string) $log['extras']['response'];
+            $datum['response'] = (string)$log['extras']['response'];
             $datum['is_error'] = $log['extras']['response']->isError();
 
             $this->data['requests'][] = $datum;
         }
+    }
+
+    private function getRequestTime(GuzzleResponse $response)
+    {
+        $time = $response->getInfo('total_time');
+
+        if (null === $time) {
+            $time = 0;
+        }
+
+        return (int)($time * 1000);
     }
 
     public function getRequests()

--- a/Resources/views/Collector/guzzle.html.twig
+++ b/Resources/views/Collector/guzzle.html.twig
@@ -44,7 +44,7 @@
                             <img alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}"
                                  style="display: none;"/>
                         </a>
-                        <code>{{ request.message }}</code>
+                        <code>{{ request.message }} ({{ request.time }} ms)</code>
                     </div>
 
                     <div id="explain-{{ i }}" style="display:none; padding-top: 1em;">


### PR DESCRIPTION
This PR adds the total time a request took to the request list in the profiler.
