### PR TITLE
Add support for a default client in the param converter

### DIFF
--- a/Request/ParamConverter/AbstractGuzzleParamConverter.php
+++ b/Request/ParamConverter/AbstractGuzzleParamConverter.php
@@ -132,6 +132,10 @@ abstract class AbstractGuzzleParamConverter implements ParamConverterInterface
                 throw new LogicException(sprintf('Unknown client \'%s\'', $options['client']));
             }
             $client = $this->clients[$options['client']];
+        } elseif (1 === count($this->clients)) {
+            $ids = array_keys($this->clients);
+            $options['client'] = reset($ids);
+            $client = reset($this->clients);
         } else {
             $client = null;
         }

--- a/Resources/doc/param_converter.md
+++ b/Resources/doc/param_converter.md
@@ -36,11 +36,19 @@ For example, to force use of the `example.client`'s `GetPost` command:
      */
     public function showAction(Post $post)
 
-Alternatively, if you just set the client it will search for a command that matches:
+If you just set the client it will search for a command that matches:
 
     /**
      * @Route("blog/{id}")
      * @ParamConverter("post", options={"client"="example.client"})
+     */
+    public function showAction(Post $post)
+    
+If you have a single client, you may omit the `client` option:
+
+    /**
+     * @Route("blog/{id}")
+     * @ParamConverter("post", options={"command"="GetPost"})
      */
     public function showAction(Post $post)
 

--- a/Tests/Functional/AbstractGuzzleParamConverterTest.php
+++ b/Tests/Functional/AbstractGuzzleParamConverterTest.php
@@ -65,13 +65,45 @@ abstract class AbstractGuzzleParamConverterTest extends TestCase
     /**
      * @expectedException \LogicException
      */
-    public function testCommandWithoutClient()
+    public function testCommandWithIndeterminableClient()
     {
         $config = $this->createConfiguration(
             'Misd\GuzzleBundle\Tests\Fixtures\Person',
             array('command' => 'UnknownCommand')
         );
         $this->converter->supports($config);
+    }
+
+    public function testCommandWithSingleClient()
+    {
+        $class = get_class($this->converter);
+        $converter = new $class;
+        $converter->registerClient('with.description', self::getClient('JMSSerializerBundle'));
+
+        $config = $this->createConfiguration(
+            'Misd\GuzzleBundle\Tests\Fixtures\Person',
+            array('command' => 'GetPersonClass')
+        );
+
+        $this->assertTrue($converter->supports($config));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Unknown command 'UnknownCommand' for client 'with.description'
+     */
+    public function testCommandWithSingleClientWithUnknownCommand()
+    {
+        $class = get_class($this->converter);
+        $converter = new $class;
+        $converter->registerClient('with.description', self::getClient('JMSSerializerBundle'));
+
+        $config = $this->createConfiguration(
+            'Misd\GuzzleBundle\Tests\Fixtures\Person',
+            array('command' => 'UnknownCommand')
+        );
+
+        $converter->supports($config);
     }
 
     /**


### PR DESCRIPTION
Hi,

When you have a single client, it makes sense to be able to omit the client id in the ParamConverter options, since there is only one possible client.

This PR allows omission of the client option.

Thanks
