### PR TITLE
Fix E_NOTICE raised by dev toolbar

### DIFF
--- a/DataCollector/GuzzleDataCollector.php
+++ b/DataCollector/GuzzleDataCollector.php
@@ -58,7 +58,7 @@ class GuzzleDataCollector extends DataCollector
 
     public function getRequests()
     {
-        return $this->data['requests'];
+        return isset($this->data['requests']) ? $this->data['requests'] : array();
     }
 
     public function getName()


### PR DESCRIPTION
I know there is another PR out for this issue. This also fixes it. Right now the bundle as-is is unusable with the current version of Symfony due to the toolbar constantly alerting issues.
