### PR TITLE
fix empty requests array for symfony 2.6

### DIFF
--- a/DataCollector/GuzzleDataCollector.php
+++ b/DataCollector/GuzzleDataCollector.php
@@ -24,6 +24,7 @@ class GuzzleDataCollector extends DataCollector
     public function __construct(ArrayLogAdapter $logAdapter)
     {
         $this->logAdapter = $logAdapter;
+        $this->data['requests'] = array();
     }
 
     public function collect(Request $request, Response $response, \Exception $exception = null)

--- a/Tests/Functional/GuzzleDataCollectorTest.php
+++ b/Tests/Functional/GuzzleDataCollectorTest.php
@@ -38,6 +38,14 @@ class GuzzleDataCollectorTest extends TestCase
         $this->assertCount(1, $collector->getRequests());
     }
 
+    public function testEmptyArrayWhenNoRequests()
+    {
+        $adapter = $this->getMock('Guzzle\Log\ArrayLogAdapter');
+        $collector = new GuzzleDataCollector($adapter);
+
+        $this->assertEquals(array(), $collector->getRequests());
+    }
+
     private function newGuzzleLog()
     {
         return array(


### PR DESCRIPTION
Create empty 'requests' array in constructor. It also adds a test to cover it.

In symfony 2.6+ when no requests are made, this throws an illegal offset exception.

Fixes #66 

Based on https://github.com/misd-service-development/guzzle-bundle/pull/67 by https://github.com/JANorman
