### PR TITLE
Parameter converter non service clients

### DIFF
--- a/DependencyInjection/Compiler/ClientCompilerPass.php
+++ b/DependencyInjection/Compiler/ClientCompilerPass.php
@@ -34,6 +34,20 @@ class ClientCompilerPass implements CompilerPassInterface
                 $container->getDefinition($id)->addMethodCall('addSubscriber', array((new Reference($plugin))));
             }
             if ('guzzle.client' !== $id && $container->hasDefinition('misd_guzzle.param_converter')) {
+                $class = $container->getDefinition($id)->getClass();
+
+                if (true === $container->hasParameter(trim($class, '%'))) {
+                    $class = $container->getParameter(trim($class, '%'));
+                }
+
+                if (
+                    false === class_exists($class)
+                    ||
+                    ($class !== 'Guzzle\Service\ClientInterface' || false === is_subclass_of($class, 'Guzzle\Service\ClientInterface'))
+                ) {
+                    continue;
+                }
+
                 $container->getDefinition('misd_guzzle.param_converter')
                     ->addMethodCall('registerClient', array($id, new Reference($id)))
                 ;

--- a/Resources/doc/param_converter.md
+++ b/Resources/doc/param_converter.md
@@ -1,7 +1,7 @@
 Param converter
 ===============
 
-Clients that have been initialised through the Symfony2 service container and have their [responses deserialized by the JMSSerializerBundle](serialization.html) can make use of the bundle's [parameter converter](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html).
+Service clients that have been initialised through the Symfony2 service container and have their [responses deserialized by the JMSSerializerBundle](serialization.html) can make use of the bundle's [parameter converter](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html).
 
 The syntax is based on the Doctrine param converter.
 

--- a/Tests/Functional/AbstractGuzzleParamConverterTest.php
+++ b/Tests/Functional/AbstractGuzzleParamConverterTest.php
@@ -203,6 +203,12 @@ abstract class AbstractGuzzleParamConverterTest extends TestCase
         $this->converter->apply($request, $config);
     }
 
+    public function testIgnoresNonServiceClients() {
+        $paramConverter = self::getContainer('SensioFrameworkExtraBundle')->get('misd_guzzle.param_converter');
+
+        $this->assertAttributeEmpty('clients', $paramConverter);
+    }
+
     /**
      * @param null   $class
      * @param array  $options

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 {
     protected static function getTestCases()
     {
-        return array('Basic', 'JMSSerializerBundle');
+        return array('Basic', 'JMSSerializerBundle', 'SensioFrameworkExtraBundle');
     }
 
     public static function setUpBeforeClass()

--- a/Tests/Functional/app/cases/SensioFrameworkExtraBundle/bundles.php
+++ b/Tests/Functional/app/cases/SensioFrameworkExtraBundle/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the MisdGuzzleBundle for Symfony2.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+    new Misd\GuzzleBundle\MisdGuzzleBundle(),
+);

--- a/Tests/Functional/app/cases/SensioFrameworkExtraBundle/config.yml
+++ b/Tests/Functional/app/cases/SensioFrameworkExtraBundle/config.yml
@@ -1,0 +1,15 @@
+imports:
+    - { resource: ./../../config/default.yml }
+
+parameters:
+    http_client: Guzzle\Http\Client
+
+services:
+    http_client:
+        class: Guzzle\Http\Client
+        tags:
+            - { name: guzzle.client }
+    parameter_http_client:
+        class: %http_client%
+        tags:
+            - { name: guzzle.client }


### PR DESCRIPTION
Fixes #59 by ignoring non-service clients when setting up the param converter.
