### PR TITLE
Change param converter guzzle client registration 'skipping' logic.

### DIFF
--- a/DependencyInjection/Compiler/ClientCompilerPass.php
+++ b/DependencyInjection/Compiler/ClientCompilerPass.php
@@ -43,7 +43,7 @@ class ClientCompilerPass implements CompilerPassInterface
                 if (
                     false === class_exists($class)
                     ||
-                    ($class !== 'Guzzle\Service\ClientInterface' || false === is_subclass_of($class, 'Guzzle\Service\ClientInterface'))
+                    false === is_subclass_of($class, 'Guzzle\Service\ClientInterface')
                 ) {
                     continue;
                 }


### PR DESCRIPTION
Hi,

First up great work on this bundle, it's been really useful, so thanks for sharing.

I was finding that the GuzzleParamConverter wasn't finding my tagged Guzzle client service and I debugged it back to a line in the ClientCompilerPass.php file.  I was using the default 'Guzzle\Service\Client' client class via the %guzzle.client.class% parameter mentioned in the docs. As you can't instantiate interface classes I've changed a piece of the logic in the ClientCompilerPass.php file that controls whether a client will be registered or not with the ParamConverter.  I initially though about changing it to test whether the class is 'Guzzle\Service\Client' but as this class implements 'Guzzle\Service\ClientInterface' then this didn't seem to add value.

If I've done something wrong in my usage of the bundle feel free to correct me.

Many thanks,

Billy
