### PR TITLE
Fix guzzle logging to 'main' channel instead of 'guzzle'

### DIFF
--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -13,7 +13,7 @@
         </service>
         <service id="misd_guzzle.log.adapter.monolog" class="%guzzle.log.adapter.monolog.class%" public="false">
             <tag name="monolog.logger" channel="guzzle"/>
-            <argument type="service" id="monolog.logger" on-invalid="ignore"/>
+            <argument type="service" id="logger" on-invalid="ignore"/>
         </service>
 
     </services>

--- a/Tests/AbstractTestCase.php
+++ b/Tests/AbstractTestCase.php
@@ -40,6 +40,7 @@ class AbstractTestCase extends PHPUnit_Framework_TestCase
         $container->setParameter('kernel.root_dir', __DIR__ . '/Fixtures');
         $container->set('service_container', $container);
         $container->set('monolog.logger', $this->getMock('Symfony\\Bridge\\Monolog\\Logger', array(), array('app')));
+        $container->setAlias('logger', 'monolog.logger');
         $container->set('jms_serializer', $this->getMock('JMS\\Serializer\\SerializerInterface'));
 
         $container->registerExtension($extension);


### PR DESCRIPTION
Looks like 47a2ee9 caused guzzle logs to be funneled to the main `app` channel instead of `guzzle`. This is because [LoggerChannelPass](https://github.com/symfony/MonologBundle/blob/v2.7.1/DependencyInjection/Compiler/LoggerChannelPass.php#L47) only changes the logger to the correct channel, if the argument is named `logger`.
