### PR TITLE
Fix framework bundle version constraint to allow 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.2",
+        "symfony/framework-bundle": ">=2.2 <4.0-dev",
         "guzzle/guzzle": "~3.0"
     },
     "suggest": {
@@ -25,8 +25,7 @@
         "symfony/monolog-bundle": "Log requests"
     },
     "conflict": {
-        "jms/serializer-bundle": "<0.11-dev",
-        "sensio/framework-extra-bundle": ">=4.0-dev"
+        "jms/serializer-bundle": "<0.11-dev"
     },
     "require-dev": {
         "doctrine/cache": "~1.0",


### PR DESCRIPTION
The `~2.2` won't let me install 3.0
