### PR TITLE
Symfony 2.7 deprecated notes fixed

### DIFF
--- a/DependencyInjection/MisdGuzzleExtension.php
+++ b/DependencyInjection/MisdGuzzleExtension.php
@@ -89,6 +89,26 @@ class MisdGuzzleExtension extends Extension
         $container->setParameter('misd_guzzle.log.format', $logFormat);
         $container->setParameter('misd_guzzle.log.enabled', $config['log']['enabled']);
 
+        $def = $container->getDefinition('guzzle.service_builder');
+        if (method_exists($def, 'setFactory')) {
+            // to be inlined in service_builder.xml when dependency on Symfony DependencyInjection is bumped to 2.6
+            $def->setFactory(array('%guzzle.service_builder.class%', 'factory'));
+        } else {
+            // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
+            $def->setFactoryClass('%guzzle.service_builder.class%');
+            $def->setFactoryMethod('factory');
+        }
+
+        $def = $container->getDefinition('misd_guzzle.response.parser.fallback');
+        if (method_exists($def, 'setFactory')) {
+            // to be inlined in serializer.xml when dependency on Symfony DependencyInjection is bumped to 2.6
+            $def->setFactory(array('%misd_guzzle.response.parser.fallback.class%', 'getInstance'));
+        } else {
+            // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
+            $def->setFactoryClass('%misd_guzzle.response.parser.fallback.class%');
+            $def->setFactoryMethod('getInstance');
+        }
+
         if (
             version_compare(Version::VERSION, '3.6', '>=')
             && $container->hasParameter('kernel.debug')

--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -15,8 +15,7 @@
         <service id="misd_guzzle.request.visitor.body" class="%misd_guzzle.request.visitor.body.class%">
             <argument type="service" id="jms_serializer.serializer" on-invalid="ignore"/>
         </service>
-        <service id="misd_guzzle.response.parser.fallback" class="%misd_guzzle.response.parser.fallback.class%"
-                 factory-class="%misd_guzzle.response.parser.fallback.class%" factory-method="getInstance"/>
+        <service id="misd_guzzle.response.parser.fallback" class="%misd_guzzle.response.parser.fallback.class%"/>
         <service id="misd_guzzle.response.parser" class="%misd_guzzle.response.parser.class%">
             <argument type="service" id="jms_serializer.serializer" on-invalid="ignore"/>
             <argument type="service" id="misd_guzzle.response.parser.fallback"/>

--- a/Resources/config/service_builder.xml
+++ b/Resources/config/service_builder.xml
@@ -9,8 +9,7 @@
     </parameters>
 
     <services>
-        <service id="guzzle.service_builder" class="%guzzle.service_builder.class%"
-                 factory-class="%guzzle.service_builder.class%" factory-method="factory">
+        <service id="guzzle.service_builder" class="%guzzle.service_builder.class%">
             <argument type="string" id="guzzle.service_builder.configuration_file">%guzzle.service_builder.configuration_file%</argument>
         </service>
     </services>

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -53,10 +53,6 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function init()
-    {
-    }
-
     public function getRootDir()
     {
         return __DIR__;


### PR DESCRIPTION
@thewilkybarkid , pls check this changes due to latest Symfony 2.7 LTS release.
