### PR TITLE
Fix monolog channels

### DIFF
--- a/DependencyInjection/Compiler/MonologCompilerPass.php
+++ b/DependencyInjection/Compiler/MonologCompilerPass.php
@@ -11,7 +11,6 @@
 
 namespace Misd\GuzzleBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -28,12 +27,16 @@ class MonologCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (false === $container->has('monolog.logger') || false === $container->getParameter('misd_guzzle.log.enabled')) {
+        if ($container->has('monolog.logger')) {
             return;
         }
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../Resources/config'));
+        $serviceIds = ['misd_guzzle.log.monolog', 'misd_guzzle.log.adapter.monolog'];
 
-        $loader->load('monolog.xml');
+        foreach ($serviceIds as $id) {
+            if ($container->hasDefinition($id)) {
+                $container->removeDefinition($id);
+            }
+        }
     }
 }

--- a/DependencyInjection/Compiler/MonologCompilerPass.php
+++ b/DependencyInjection/Compiler/MonologCompilerPass.php
@@ -31,7 +31,7 @@ class MonologCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $serviceIds = ['misd_guzzle.log.monolog', 'misd_guzzle.log.adapter.monolog'];
+        $serviceIds = array('misd_guzzle.log.monolog', 'misd_guzzle.log.adapter.monolog');
 
         foreach ($serviceIds as $id) {
             if ($container->hasDefinition($id)) {

--- a/DependencyInjection/MisdGuzzleExtension.php
+++ b/DependencyInjection/MisdGuzzleExtension.php
@@ -89,6 +89,10 @@ class MisdGuzzleExtension extends Extension
         $container->setParameter('misd_guzzle.log.format', $logFormat);
         $container->setParameter('misd_guzzle.log.enabled', $config['log']['enabled']);
 
+        if ($config['log']['enabled']) {
+            $loader->load('monolog.xml');
+        }
+
         if (
             version_compare(Version::VERSION, '3.6', '>=')
             && $container->hasParameter('kernel.debug')

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -13,7 +13,7 @@
         </service>
         <service id="misd_guzzle.log.adapter.monolog" class="%guzzle.log.adapter.monolog.class%" public="false">
             <tag name="monolog.logger" channel="guzzle"/>
-            <argument type="service" id="monolog.logger" on-invalid="ignore"/>
+            <argument type="service" id="logger" on-invalid="ignore"/>
         </service>
 
     </services>

--- a/Tests/AbstractTestCase.php
+++ b/Tests/AbstractTestCase.php
@@ -41,6 +41,7 @@ class AbstractTestCase extends PHPUnit_Framework_TestCase
         $container->set('service_container', $container);
         $container->set('monolog.logger', $this->getMock('Symfony\\Bridge\\Monolog\\Logger', array(), array('app')));
         $container->set('jms_serializer', $this->getMock('JMS\\Serializer\\SerializerInterface'));
+        $container->setAlias('logger', 'monolog.logger');
 
         $container->registerExtension($extension);
         $extension->load($config, $container);


### PR DESCRIPTION
Load Monolog services by default _(if logging is enabled)_, and remove them afterwards in the compiler pass if Monolog is not available. This way, the log adapter will use the `guzzle` channel properly, assigned by the service definition and not the default channel `app`, as it does now.

Fixes #35

In my use case, I wanted to exclude all the _Guzzle_ logs from a command output, but I couldn't since those logs were being logged into the `app` channel.
